### PR TITLE
Fix BroccoliMergeTrees error - only merge tree present in treeForVendor

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,6 @@ module.exports = {
     var momentTree = new Funnel(path.dirname(require.resolve('js-cookie')), {
       files: ['js.cookie.js'],
     });
-    return new MergeTrees([vendorTree, momentTree]);
+    return vendorTree ? new MergeTrees([vendorTree, momentTree]) : momentTree;
   }
 };


### PR DESCRIPTION
Fixes `BroccoliMergeTrees: Expected Broccoli node, got undefined for inputNodes[0]` introduced by https://github.com/joebartels/ember-cli-js-cookie/pull/2

Related https://github.com/martndemus/ember-font-awesome/issues/120